### PR TITLE
fix: introduce configurable `excludeInvalid` option for DatoCMS 

### DIFF
--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -1193,7 +1193,7 @@ type DownloadLinkRecord implements RecordInterface {
   label: String!
 }
 
-"""Block of type Card info and service (external_link)"""
+"""Block of type External link (external_link)"""
 type ExternalLinkRecord implements RecordInterface {
   _createdAt: DateTime!
 

--- a/src/lib/datocms.ts
+++ b/src/lib/datocms.ts
@@ -14,10 +14,12 @@ export async function executeQuery<Result, Variables>(
   const token = options?.includeDrafts
     ? getEnv("DATOCMS_DRAFT_API_TOKEN")
     : (getEnv("DATOCMS_MANAGEMENT_API_TOKEN") ?? getEnv("DATOCMS_API_TOKEN"));
+  const excludeInvalid =
+    options?.excludeInvalid ?? (options?.includeDrafts ? false : true);
 
   const result = await libExecuteQuery(query, {
     variables: options?.variables,
-    excludeInvalid: true,
+    excludeInvalid,
     includeDrafts: options?.includeDrafts,
     environment: getEnv("DATOCMS_ENVIRONMENT"),
     token,
@@ -29,4 +31,5 @@ export async function executeQuery<Result, Variables>(
 type ExecuteQueryOptions<Variables> = {
   variables?: Variables;
   includeDrafts?: boolean;
+  excludeInvalid?: boolean;
 };


### PR DESCRIPTION
introduce configurable `excludeInvalid` option for DatoCMS  queries and update `ExternalLinkRecord` schema comment.